### PR TITLE
set up the pam pecl module for athentication from php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ playbooks/default.yml
 ext/*
 playbooks/dynamic.yml
 vm_data
+modules

--- a/localconfig.yml.defaults
+++ b/localconfig.yml.defaults
@@ -48,6 +48,9 @@ platform: auto
 #
 profile: classroom_server
 
+# Use this profile for swag development. Also see provision__data_dir below.
+# profile: swag_dev
+
 #### ANSIBLE VARS ####
 # You can fine-tune settings here. 
 # Most sever roles have settings defined in:
@@ -120,3 +123,6 @@ vars:
   #
   #     playbooks/roles/portal/defaults/main.yml
   #
+
+  # Will make checked out modules accesible to the host.
+  #provision__data_dir: "{{provision__base_dir}}/provision/modules"

--- a/playbooks/roles/swagportal/tasks/main.yml
+++ b/playbooks/roles/swagportal/tasks/main.yml
@@ -14,14 +14,29 @@
     repo=https://github.com/tunapanda/swagportal
     recursive=true
     dest={{swagportal__root}}
-    
+
 - name: Deploy swagportal config
   template:
     src="config.ini"
     dest="{{swagportal__root}}/config.ini"
     owner="{{swagportal__owner}}"
     group="{{swagportal__group}}"
-    
+
+- apt: name={{item}}
+  with_items:
+    - libpam0g-dev
+    - php5-dev
+    - php-pear
+
+- command: >
+    pecl install pam
+    creates=/usr/lib/php5/20121212/pam.so
+
+- lineinfile:
+    dest: /etc/php5/fpm/php.ini
+    line: extension=pam.so
+  notify: restart fpm
+
 # TODO: Figure out a better way. Probably something
 # other than PAM, unfortunately. 
 - name: Open shadow access (TEMPORARY hack)

--- a/playbooks/roles/swagportal/tasks/main.yml
+++ b/playbooks/roles/swagportal/tasks/main.yml
@@ -27,7 +27,8 @@
     - libpam0g-dev
     - php5-dev
     - php-pear
-    
+    - php5-curl
+
 - command: pecl list pam
   ignore_errors: true
   register: check_pam

--- a/playbooks/roles/swagportal/tasks/main.yml
+++ b/playbooks/roles/swagportal/tasks/main.yml
@@ -27,10 +27,14 @@
     - libpam0g-dev
     - php5-dev
     - php-pear
+    
+- command: pecl list pam
+  ignore_errors: true
+  register: check_pam
 
 - command: >
     pecl install pam
-    creates=/usr/lib/php5/20121212/pam.so
+  when: check_pam.rc != 0
 
 - lineinfile:
     dest: /etc/php5/fpm/php.ini


### PR DESCRIPTION
Fixed this I think...

Maybe it needs some cleaning up, take a look!

Also, it checks if the extension is installed by checking the file `/usr/lib/php5/20121212/pam.so` which feels like it would not be 100% reliable. Or maybe it is? Anyway I asked a question about it here, we will see if it gets any attention:

http://stackoverflow.com/questions/30144532/can-i-rely-on-php-extensions-to-be-stored-in-usr-lib-php5-20121212